### PR TITLE
Remove document hidden check

### DIFF
--- a/desktop-notify.js
+++ b/desktop-notify.js
@@ -160,9 +160,7 @@
         }
         return settings;
     }
-    function isDocumentHidden() {
-        return settings.pageVisibility ? (document.hidden || document.msHidden || document.mozHidden || document.webkitHidden) : true;
-    }
+    
     function createNotification(title, options) {
         var notification,
             notificationWrapper;
@@ -173,7 +171,7 @@
 
             Title and icons are required. Return undefined if not set.
          */
-        if (isSupported && isDocumentHidden() && isString(title) && (options && (isString(options.icon) || isObject(options.icon))) && (permissionLevel() === PERMISSION_GRANTED)) {
+        if (isSupported && isString(title) && (options && (isString(options.icon) || isObject(options.icon))) && (permissionLevel() === PERMISSION_GRANTED)) {
             notification = getNotification(title, options);
         }
         notificationWrapper = getWrapper(notification);


### PR DESCRIPTION
We should let the user decided if he want to show the notification when the document visible too.
Specially because document.hidden is only true for when minimized or tab is switched. If the user just alt-tab applications, the notification will never be displayed.

I suppose a common solution would be to check for window.document.hasFocus() instead, but, then again, I think we should leave this to the user.