### PR TITLE
Implemented auto-closing notification for chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The <b>notify</b> global object provides a single global namespace within which 
                     <li>body / String / -- The notification’s subtitle. For IE it provides an accessible description of the information conveyed by the icon overlay. Choose text that can be read by screen readers.</li>
                     <li>icon / String/Object / (required) -- The icon that will be set as a custom overlay for IE and notification displayed from Chrome running on Windows. Note that icon by default is not required for Chrome, Safari & Firefox, but is required for IE. In order to unify the implementations, the icon should be always provided in order to display notifications for all supported browsers. icon param could be String with icon's location, but it could be also an Object with the following properties: {"x16": Icon for IE only. The icon should be 16x16px *.ico format, "x32": Icon for all other browsers(Chrome on Windows, Firefox). The icon's size should be 32x32px, supported formats: jpg/png/ico}. Once again - Safari and Chrome on MacOS does not allow icon to be set. For Firefox Mobile, the icon is always Firefox icon. </li>
                     <li>tag -- The notification’s unique identifier. This prevents duplicate entries from appearing in Notification Center if the user has multiple instances of your website open at once. (Apply for Chrome & Safari only)</li>
-                    <li>timeout -- interval for auto-closing notification. (Does not work for Chrome on MacOS)</li>
+                    <li>timeout -- interval for auto-closing notification.</li>
                 </ul>
             </li>
         </ul>

--- a/desktop-notify.js
+++ b/desktop-notify.js
@@ -39,7 +39,7 @@
              *
              * Also, we canNOT detect if msIsSiteMode method exists, as it is
              * a method of host object. In IE check for existing method of host
-             * object returns undefined. So, we try to run it - if it runs 
+             * object returns undefined. So, we try to run it - if it runs
              * successfully - then it is IE9+, if not - an exceptions is thrown.
              */
             try {
@@ -104,6 +104,9 @@
                     if (notification.close) {
                         //http://code.google.com/p/ff-html5notifications/issues/detail?id=58
                         notification.close();
+                    }
+                    else if (notification.cancel) {
+                        notification.cancel();
                     } else if (win.external && win.external.msIsSiteMode()) {
                         if (notification.ieVerification === ieVerification) {
                             win.external.msSiteModeClearIconOverlay();
@@ -119,7 +122,7 @@
         if (win.webkitNotifications && win.webkitNotifications.checkPermission) {
             /*
              * Chrome 23 supports win.Notification.requestPermission, but it
-             * breaks the browsers, so use the old-webkit-prefixed 
+             * breaks the browsers, so use the old-webkit-prefixed
              * win.webkitNotifications.checkPermission instead.
              *
              * Firefox with html5notifications plugin supports this method
@@ -152,7 +155,7 @@
         return permission;
     }
     /**
-     *  
+     *
      */
     function config(params) {
         if (params && isObject(params)) {


### PR DESCRIPTION
In Chrome, we use not `close()` but `cancel()`  to close notification.
http://stackoverflow.com/questions/5732031/chrome-extension-development-auto-close-the-notification-box

If you will accept this PR, please tell me how to make minified version of js.
