### PR TITLE
Allow to add listeners to notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ The <b>notify</b> global object provides a single global namespace within which 
         Returns an object with the following methods:
         <ul>
             <li>close() -- call to close the notification.</li>
+            <li>on() -- add an event listener to the notification. Supported listeners are 'click', 'show', 'error', and 'close'.</li>
         </ul>
     </li>
 </ul>

--- a/desktop-notify.js
+++ b/desktop-notify.js
@@ -113,6 +113,11 @@
                         }
                     }
                 }
+            },
+            on: function (type, listener) {
+                if (notification && notification.addEventListener) {
+                    return notification.addEventListener(type, listener);
+                }
             }
         };
     }


### PR DESCRIPTION
Expose a 'on' method on the notification wrapper so the user can add an event listener on the notification object. 
Events that are supported are click, show, error and close.