### PR TITLE
Add CDNJS version badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![Build Status](https://travis-ci.org/ttsvetko/HTML5-Desktop-Notifications.svg?branch=master)
 [![CircleCI](https://circleci.com/gh/ttsvetko/HTML5-Desktop-Notifications/tree/master.svg?style=svg)](https://circleci.com/gh/ttsvetko/HTML5-Desktop-Notifications/tree/master)
+[![CDNJS](https://img.shields.io/cdnjs/v/HTML5Notification.svg)](https://cdnjs.com/libraries/HTML5Notification)
 
 # HTML 5 Desktop Notification
 


### PR DESCRIPTION
This will add the badge to show its version on CDNJS and also link to its page on CDNJS!
